### PR TITLE
Added container scope for yetiforce 4.4

### DIFF
--- a/yetiforce_python/__init__.py
+++ b/yetiforce_python/__init__.py
@@ -122,8 +122,7 @@ class YetiForceAPI(object):
         url = '/'.join([x for x in
                         [self._ws_url, self.WEBSERVICE, self.container, module, action]
                         if x is not None])
-        
-        print(url)
+
         response = self._session.request(method=method, url=url, params=params,
                                          data=data, json=json, headers=headers)
         if response.status_code >= 500:

--- a/yetiforce_python/__init__.py
+++ b/yetiforce_python/__init__.py
@@ -70,9 +70,10 @@ class YetiForceAPI(object):
         def update(self, record_id, data):
             return self._api.update_record(self._name, record_id, data)
 
-    def __init__(self, url, ws_user, ws_pass, ws_key, username, password,
+    def __init__(self, url, container, ws_user, ws_pass, ws_key, username, password,
                  verify=False):
         self._ws_url = url.rstrip('/')
+        self.container = container
         self._ws_auth = (ws_user, ws_pass)
         self._ws_key = ws_key
         self._verify = verify
@@ -119,8 +120,10 @@ class YetiForceAPI(object):
         headers.update(extra_headers or {})
 
         url = '/'.join([x for x in
-                        [self._ws_url, self.WEBSERVICE, module, action]
+                        [self._ws_url, self.WEBSERVICE, self.container, module, action]
                         if x is not None])
+        
+        print(url)
         response = self._session.request(method=method, url=url, params=params,
                                          data=data, json=json, headers=headers)
         if response.status_code >= 500:


### PR DESCRIPTION
I added support for yetiforce 4.4 by implementing the "container" scope in api requests. I chose to add a client initialization attribute, I assumed this would be ideal since yetiforce has added several external app integration methods, portal, restapi, etc. Each of these needs unique tokens so you would need new clients for each type anyway. Hope this helps!